### PR TITLE
Add Navigation Bar with Home Page Navigation for Sign-in Page

### DIFF
--- a/hiring-portal/src/Components/Navbar.jsx
+++ b/hiring-portal/src/Components/Navbar.jsx
@@ -17,11 +17,16 @@ const Navbar = () => {
   const location = useLocation();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [activeTab, setActiveTab] = useState('/');
+  const [hideElements, setHideElements] = useState(false);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
     setIsLoggedIn(!!token); 
     setActiveTab(location.pathname); 
+
+    // Hide elements on specific routes (e.g., /signin, /signup)
+    const routesToHideElements = ['/signin', '/signup']; // Add the routes where you want to hide elements
+    setHideElements(routesToHideElements.includes(location.pathname));
   }, [location.pathname]);
 
   const handlePostJob = () => {
@@ -38,7 +43,7 @@ const Navbar = () => {
         console.error('Error fetching user profile:', error);
       });
     } 
-  }
+  };
 
   return (
     <div className="navbar">
@@ -52,34 +57,43 @@ const Navbar = () => {
           <HomeIcon />
           <Link to="/" onClick={() => setActiveTab('/')}><span>Home</span></Link>
         </div>
-        <div className={`icon jobs ${activeTab === '/jobcard' ? 'active' : ''}`}>
-          <WorkIcon />
-          <Link to="/jobcard" onClick={() => setActiveTab('/jobcard')}><span>Jobs</span></Link>
-        </div>
-        <div className={`icon aboutus ${activeTab === '/about' ? 'active' : ''}`}>
-          <InfoIcon />
-          <Link to="/about" onClick={() => setActiveTab('/about')}><span>About</span></Link>
-        </div>
-        <div className={`icon login ${activeTab === '/profile' ? 'active' : ''}`}>
-          {isLoggedIn ? (
-            <>
-              <AccountCircleIcon />
-              <Link to="/profile" onClick={() => setActiveTab('/profile')}><span>Profile</span></Link>
-            </>
-          ) : (
-            <>
-              <LoginIcon />
-              <Link to="/signin" onClick={() => setActiveTab('/signin')}><span>Login</span></Link>
-            </>
-          )}
-        </div>
+        {!hideElements && (
+          <>
+            <div className={`icon jobs ${activeTab === '/jobcard' ? 'active' : ''}`}>
+              <WorkIcon />
+              <Link to="/jobcard" onClick={() => setActiveTab('/jobcard')}><span>Jobs</span></Link>
+            </div>
+            <div className={`icon aboutus ${activeTab === '/about' ? 'active' : ''}`}>
+              <InfoIcon />
+              <Link to="/about" onClick={() => setActiveTab('/about')}><span>About</span></Link>
+            </div>
+            <div className={`icon login ${activeTab === '/profile' ? 'active' : ''}`}>
+              {isLoggedIn ? (
+                <>
+                  <AccountCircleIcon />
+                  <Link to="/profile" onClick={() => setActiveTab('/profile')}><span>Profile</span></Link>
+                </>
+              ) : (
+                <>
+                  <LoginIcon />
+                  <Link to="/signin" onClick={() => setActiveTab('/signin')}><span>Login</span></Link>
+                </>
+              )}
+            </div>
+          </>
+        )}
       </div>
-      <div className="posting">
-        <span onClick={handlePostJob}>Employer/Post Job</span>
-        <LaunchIcon className="posting-icon" />
-      </div>
+      {!hideElements && (
+        <div className="posting">
+          <span onClick={handlePostJob}>Employer/Post Job</span>
+          <LaunchIcon className="posting-icon" />
+        </div>
+      )}
     </div>
   );
 };
 
 export default Navbar;
+
+
+

--- a/hiring-portal/src/Components/Signin.jsx
+++ b/hiring-portal/src/Components/Signin.jsx
@@ -1,13 +1,17 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import Navbar from "./Navbar";
 import "../CSS/signin.css";
 import jobImage from '../job_search.png'; // Replace with the actual path to your image
 import logo from '../logo.png';
+
 import { ClipLoader } from 'react-spinners'; // Import the spinner
 
 const SignIn = () => {
+ 
   const navigate = useNavigate();
 
   const [email, setEmail] = useState('');
@@ -49,7 +53,9 @@ const SignIn = () => {
   };
 
   return (
+    
     <div className="bg">
+      <Navbar />
       {loadingImage && (
         <div className="loader-overlay">
           <ClipLoader color="#3498db" loading={loadingImage} size={50} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hiring-portal",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### Pull Request Title

**Issue Reference:**
<!-- If applicable, reference the issue number. -->
Closes: #4 

**Description:**
<!-- Please include a summary of the changes and which issue is fixed. -->
his PR implements a navigation bar on the sign-in page that includes a "Home" button for navigation. The navigation bar is conditionally displayed to hide elements like "Jobs," "About," and "Login" when on the sign-in page to keep the UI clean and focused.

Added a conditional check to hide "Jobs," "About," and "Login" sections on the /signin and /signup routes.
Implemented home page navigation in the sign-in form to ensure users can navigate back to the home page if needed.

**Screenshots:**
Before:
<img width="1437" alt="Screenshot 2024-10-02 at 2 16 03 PM" src="https://github.com/user-attachments/assets/f4c3e30e-9ec3-4cab-bfb7-4ca178ff20b9">

After:
<img width="1446" alt="Screenshot 2024-10-02 at 2 11 29 PM" src="https://github.com/user-attachments/assets/ab263381-3620-43af-a2ca-55a096ac593d">


<!-- Add screenshots or videos to show the before and after, if applicable. -->

**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ X] Enhancement

**Checklist:**
- [ X] I have tested my changes and verified that they work
- [ X] My code follows the style guidelines of this project
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes

**Additional Information:**
The home page link is added to ensure seamless navigation for users, and the conditional rendering is added to hide unnecessary elements on the sign-in page.
<!-- Add any other information that is important to this PR. -->
