### PR TITLE
Feat : Add Preview and Upload Options for Application Files

### DIFF
--- a/hiring-portal/src/CSS/ApplicationForm.css
+++ b/hiring-portal/src/CSS/ApplicationForm.css
@@ -85,3 +85,63 @@
       padding: 8px;
       border-radius: 4px;
     }
+    
+    .file-preview-dialog {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: white;
+      padding: 30px;
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.2);
+      z-index: 1000;
+      width: 70%;
+      max-width: 750px;
+      display: flex;
+      flex-direction: column;
+      transition: height 0.3s ease;
+    }
+    
+    .file-preview-dialog h3 {
+      font-size: 24px;
+      margin-bottom: 20px;
+      color: #333;
+    }
+    
+    .preview-options {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 20px;
+      gap: 15px;
+    }
+    
+    .preview-options button {
+      border: none;
+      border-radius: 5px;
+      padding: 10px 20px;
+      cursor: pointer;
+      background-color: #189F93;
+      color: white;
+      font-size: 16px;
+      transition: background-color 0.3s ease;
+    }
+    
+    .preview-options button:hover {
+      background-color: #147c72;
+    }
+    
+    .file-preview {
+      flex-grow: 1;
+      overflow: auto;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+    }
+    
+    .file-preview img,
+    .file-preview iframe {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border: none;
+    }


### PR DESCRIPTION
**Issue Reference:** #181 

**Description:**
Added a catalog box to prompt users with the option to either upload or preview a file upon selection. If 'Preview' is clicked, the file's preview opens, and if 'Upload' is clicked, the file is uploaded directly.

**Screenshots:**
![image](https://github.com/user-attachments/assets/937b1de7-d312-4c5d-b49a-43026bdc21d4)
![image](https://github.com/user-attachments/assets/3dffb701-b51a-4b2f-ac09-e817f4c2cffd)

**Type of change:**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Enhancement

**Checklist:**
- [x] I have tested my changes and verified that they work
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

**Additional Information:**
No additional modules are required for that.
