### PR TITLE
Add show password functionality, implement welcome to HireHub redirection, and fix 'remember me' alignment

### DIFF
--- a/hiring-portal/src/CSS/signin.css
+++ b/hiring-portal/src/CSS/signin.css
@@ -76,6 +76,7 @@
 
 .signin-page::before {
   content: "";
+  pointer-events: none;
   position: absolute;
   top: 0;
   left: 0;
@@ -171,7 +172,7 @@
 
 .extra-options {
   text-align: center;
-  margin-top: 10px;
+  margin-top: 20px;
 }
 
 .extra-options a {
@@ -262,8 +263,8 @@
 
 .eye-icon {
   position: absolute;
-  right: 10px;
-  top: 60%;
+  right: 30px;
+  top: 70%;
   transform: translateY(-50%);
   cursor: pointer;
 }

--- a/hiring-portal/src/CSS/signup.css
+++ b/hiring-portal/src/CSS/signup.css
@@ -221,3 +221,16 @@ a {
   text-decoration: none;
   color: #555;
 }
+
+
+.password-field {
+  position: relative;
+}
+
+.eye-icon {
+  position: absolute;
+  right: 10px;
+  top: 60%;
+  transform: translateY(-50%);
+  cursor: pointer;
+}

--- a/hiring-portal/src/Components/Signin.jsx
+++ b/hiring-portal/src/Components/Signin.jsx
@@ -9,6 +9,7 @@ import logo from "../assests/logo.png";
 import { ClipLoader } from "react-spinners"; // Import the spinner
 import { FaEye, FaEyeSlash } from "react-icons/fa"; // Import eye icons from react-icons
 import { Modal, Input, Button } from "antd";
+import { Link } from "react-router-dom";
 
 const SignIn = () => {
   const navigate = useNavigate();
@@ -105,10 +106,12 @@ const SignIn = () => {
       )}
       <div className="signin-page">
         <center>
+          <Link to="/">
           <div className="welcom1">
             <h1>Welcome to&nbsp;&nbsp;</h1>
             <img src={logo} alt="Logo" />
           </div>
+          </Link>
         </center>
         <div className="signin-data">
           <div className="signin-image">
@@ -148,12 +151,6 @@ const SignIn = () => {
                   </span>
                 </div>
               </div>
-              <div style={{ display: "flex", gap: "1rem" }}>
-                <button type="submit">Sign In</button>
-                <button type="button" onClick={showForgotPasswordModal}>
-                  Forgot Password
-                </button>
-              </div>
               <div className="remember-forgot">
                 <div className="remember-me">
                   <input
@@ -165,6 +162,12 @@ const SignIn = () => {
                   <label htmlFor="rememberMe">Remember Me</label>
                 </div>
               </div>
+              <div style={{ display: "flex", gap: "1rem" }}>
+                <button type="submit">Sign In</button>
+                <button type="button" onClick={showForgotPasswordModal}>
+                  Forgot Password
+                </button>
+              </div>              
             </form>
             <div className="extra-options">
               <a href="/signup">Don't have an account? Sign Up</a>

--- a/hiring-portal/src/Components/Signup.jsx
+++ b/hiring-portal/src/Components/Signup.jsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 import { storage } from '../firebase/firebase';
 import Navbar from "./Navbar";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 
 const Signup = () => {
   const navigate = useNavigate();
@@ -37,6 +38,8 @@ const Signup = () => {
     cgpa: "",
     pastJobs: [{ company: "", role: "", duration: "", details: "" }] // Initialize with one job entry
   });
+
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e) => {
     const { name, value, type, checked, files } = e.target;
@@ -125,6 +128,10 @@ const Signup = () => {
       console.error('Error submitting form:', error.response.data);
       toast.error('Error creating user. Please try again.'); // Show error toast
     }
+  };
+  
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
   };
   
   return (
@@ -249,15 +256,19 @@ const Signup = () => {
               />
             </label>
             <br />
-            <label>
+            <label className="password-field">
               Password:
               <input
-                type="password"
+                type={showPassword ? "text" : "password"}
                 name="password"
                 className="signupinput"
                 value={formData.password}
                 onChange={handleChange}
               />
+              <span onClick={togglePasswordVisibility} className="eye-icon">
+                {showPassword ? <FaEyeSlash /> : <FaEye />}
+              </span>
+
             </label>
             <br />
             <label>


### PR DESCRIPTION
**Issue Reference:**
#166 

**Description:**

Show Password Functionality:
1. Added the ability for users to toggle the visibility of their password in the sign-up form.
2. Users can now click on the eye icon to show or hide the password as needed.

Welcome to HireHub Redirection:
1. Implemented a redirect link for the "Welcome to HireHub" on sign in page. This now correctly navigates the user to the homepage  when clicked.

Fix 'Remember Me' Alignment:
1. Corrected the alignment issue with the 'Remember Me' checkbox and label in the sign-in form

**Screenshots:**
1 ->
Before 
![Screenshot (352)](https://github.com/user-attachments/assets/aa0fa4fd-92e6-49f8-854d-1bde1cff9e3b)

After
![Screenshot (353)](https://github.com/user-attachments/assets/48434b41-111a-4e34-ab76-462ce698c04c)

2 ->
Before
https://github.com/user-attachments/assets/56e526a8-e184-461b-ac79-dc62517b27f9

After
https://github.com/user-attachments/assets/2c26e674-fcf3-4ca2-aedc-d0c6e4b1ae11

3 ->
Before
![Screenshot_16-10-2024_12818_main--hirehub07 netlify app](https://github.com/user-attachments/assets/7e72f9e2-2e1e-4dec-b0bf-7edeec677ac4)

After
![Screenshot (350)](https://github.com/user-attachments/assets/113c727e-8a57-471f-9996-a0ede31c88e6)


**Type of change:**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Enhancement

