### PR TITLE
Add authentication to routes

### DIFF
--- a/hiring-portal/Backend/middlewares/authMiddleware.js
+++ b/hiring-portal/Backend/middlewares/authMiddleware.js
@@ -1,0 +1,20 @@
+// authMiddleware.js
+const jwt = require('jsonwebtoken');
+
+const authMiddleware = (req, res, next) => {
+    const token = req.header('Authorization')?.split(' ')[1]; // Expecting `Bearer <token>`
+
+    if (!token) {
+        return res.status(401).json({ message: "Access Denied. No token provided." });
+    }
+
+    try {
+        const decoded = jwt.verify(token, process.env.JWT_SECRET); // Ensure to set JWT_SECRET in environment
+        req.user = decoded; // Attach decoded token data to the request
+        next(); // Proceed to the next middleware or route handler
+    } catch (error) {
+        res.status(403).json({ message: "Invalid token" });
+    }
+};
+
+module.exports = authMiddleware;

--- a/hiring-portal/Backend/routes/blogRoutes.js
+++ b/hiring-portal/Backend/routes/blogRoutes.js
@@ -1,11 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const blogController = require('../controllers/blogController');
+const authMiddleware = require('../middlewares/authMiddleware');
+  // Import auth middleware
 
-router.post('/create-blog', blogController.postBlog);
-router.get('/all-blog', blogController.getAllBlogs);
-router.delete('/delete-all', blogController.deleteAllBlogs);
-router.delete('/delete-by-id/:id', blogController.deleteBlog);
-router.get('/get-by-id/:id', blogController.getBlog);
+// Secure routes with authMiddleware
+router.post('/create-blog', authMiddleware, blogController.postBlog);
+router.get('/all-blog', authMiddleware, blogController.getAllBlogs);
+router.delete('/delete-all', authMiddleware, blogController.deleteAllBlogs);
+router.delete('/delete-by-id/:id', authMiddleware, blogController.deleteBlog);
+router.get('/get-by-id/:id', authMiddleware, blogController.getBlog);
 
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "GSSOC_hiring-portal",
+  "name": "hiring-portal",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
### Pull Request Title

**Issue Reference:**
## fixes #247 

**Description:**
This PR adds the authMiddleware to the blog routes so that unauthenticated users are not allowed.

**Screenshots:**
![Screenshot 2024-10-28 213517](https://github.com/user-attachments/assets/dbeb6a11-2b60-4ac9-b9f1-dbbcb3fadb0e)
![Screenshot 2024-10-28 213809](https://github.com/user-attachments/assets/4a60f61d-9ab4-440f-9d18-54b1c59bd2a0)
![Screenshot 2024-10-28 213825](https://github.com/user-attachments/assets/098d22e8-8418-4670-aa9d-ed1474b234eb)

**Type of change:**
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Enhancement

**Checklist:**
- [X] I have tested my changes and verified that they work
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


