### PR TITLE
Add PDF Text Preview Endpoint #295

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -18,9 +18,13 @@
 │   │   │   ├── companyController.js
 │   │   │   ├── contactController.js
 │   │   │   ├── directController.js
+│   │   │   ├── forgotPasswordController.js
 │   │   │   ├── jobController.js
 │   │   │   ├── otherApiController.js
+│   │   │   ├── otpVerifyController.js
 │   │   │   └── userController.js
+│   │   ├── middlewares/
+│   │   │   └── authMiddleware.js
 │   │   ├── models/
 │   │   │   ├── Application.js
 │   │   │   ├── Assesment.js
@@ -1200,14 +1204,15 @@
 │       ├── App.js
 │       ├── App.test.js
 │       ├── CSS/
+│       │   ├── About.module.css
 │       │   ├── ApplicationForm.css
+│       │   ├── ApplicationForm.module.css
 │       │   ├── NotFound.css
-│       │   ├── about.css
 │       │   ├── admin.css
 │       │   ├── ass.css
 │       │   ├── assessmentResults.css
 │       │   ├── backtotop.css
-│       │   ├── blog.css
+│       │   ├── blog.module.css
 │       │   ├── coding.css
 │       │   ├── company.css
 │       │   ├── contactus.css
@@ -1215,26 +1220,26 @@
 │       │   ├── createBlog.css
 │       │   ├── dashboard.css
 │       │   ├── employer.css
-│       │   ├── faqSection.css
-│       │   ├── footer.css
-│       │   ├── herosection.css
-│       │   ├── interview.css
+│       │   ├── faqSection.module.css
+│       │   ├── footer.module.css
+│       │   ├── herosection.module.css
+│       │   ├── interview.module.css
 │       │   ├── job.css
-│       │   ├── jobcard.css
+│       │   ├── jobcard.module.css
 │       │   ├── jobgrid.css
 │       │   ├── joblist.css
 │       │   ├── jobpage.css
 │       │   ├── jobpostform.css
 │       │   ├── jobs.css
 │       │   ├── manageJobs.css
-│       │   ├── middleview.css
-│       │   ├── navbar.css
-│       │   ├── newJobCard.css
-│       │   ├── postview.css
-│       │   ├── privacyPolicy.css
+│       │   ├── middleview.module.css
+│       │   ├── navbar.module.css
+│       │   ├── newJobCard.module.css
+│       │   ├── postview.module.css
+│       │   ├── privacyPolicy.module.css
 │       │   ├── profile.css
 │       │   ├── readMoreBlog.css
-│       │   ├── resumeAnalyzer.css
+│       │   ├── resumeAnalyzer.module.css
 │       │   ├── shortlist.css
 │       │   ├── signin.css
 │       │   ├── signup.css
@@ -1264,7 +1269,6 @@
 │       │   ├── Error404.jsx
 │       │   ├── Faqs.jsx
 │       │   ├── Footer.jsx
-│       │   ├── ForgotPassword.jsx
 │       │   ├── GoogleTranslate.jsx
 │       │   ├── GoogleTranslator.jsx
 │       │   ├── HeroSection.jsx

--- a/hiring-portal/Backend/ats.py
+++ b/hiring-portal/Backend/ats.py
@@ -15,6 +15,26 @@ if not palm_api_key:
     raise ValueError("API key is missing. Please set your API key in the environment variables.")
 palm.configure(api_key=palm_api_key)
 
+# Return only the first 1000 characters for preview purposes
+@app.route('/preview', methods=['POST'])
+def preview_text():
+    try:
+        if 'file' not in request.files:
+            return jsonify({"error": "PDF file is required."}), 400
+
+        file = request.files['file']
+        if not file.filename.endswith('.pdf'):
+            return jsonify({"error": "File must be in PDF format."}), 400
+            
+        text = extract_text_from_pdf(file)
+        return jsonify({"text": text[:1000]}), 200
+
+    except PyPDF2.errors.PdfReadError:
+        return jsonify({"error": "Error reading the PDF file. Please ensure it is valid."}), 400
+    except Exception as e:
+        print("Unexpected Error:", str(e))  
+        return jsonify({"error": "An unexpected error occurred while processing the PDF."}), 500
+
 @app.route('/analyze', methods=['GET'])
 def health_check():
     return jsonify({"message": "Server running!"}), 200

--- a/hiring-portal/src/Components/ResumeAnalyzer.jsx
+++ b/hiring-portal/src/Components/ResumeAnalyzer.jsx
@@ -1,14 +1,17 @@
 import React, { useState } from 'react';
 import axios from 'axios';
-import styles from '../CSS/resumeAnalyzer.module.css'
-import Navbar from "../Components/Navbar"
-import Footer from "../Components/Footer"
+import styles from '../CSS/resumeAnalyzer.module.css';
+import Navbar from "../Components/Navbar";
+import Footer from "../Components/Footer";
 
 const ResumeAnalyzer = () => {
     const [resume, setResume] = useState(null);
     const [jobDescription, setJobDescription] = useState(null);
     const [loading, setLoading] = useState(false);
-    const [result, setResult] = useState();
+    const [result, setResult] = useState(null);
+    const [resumePreview, setResumePreview] = useState('');
+    const [jobDescPreview, setJobDescPreview] = useState('');
+    const [error, setError] = useState('');
 
     const handleDrop = (event, type) => {
         event.preventDefault();
@@ -16,8 +19,10 @@ const ResumeAnalyzer = () => {
         if (files.length > 0) {
             if (type === 'resume') {
                 setResume(files[0]);
+                readFileContent(files[0], setResumePreview);
             } else {
                 setJobDescription(files[0]);
+                readFileContent(files[0], setJobDescPreview);
             }
         }
     };
@@ -25,6 +30,7 @@ const ResumeAnalyzer = () => {
     const handleSubmit = async (e) => {
         e.preventDefault();
         setLoading(true);
+        setError('');
         const formData = new FormData();
         formData.append('resume', resume);
         formData.append('jobDescription', jobDescription);
@@ -33,19 +39,34 @@ const ResumeAnalyzer = () => {
             const response = await axios.post('http://127.0.0.1:8000/analyze', formData, {
                 headers: { 'Content-Type': 'multipart/form-data' },
             });
-            console.log(response);
-            setLoading(false)
-            const analysisResult = JSON.parse(response.data.analysis);
-            setResult(analysisResult);
+            setLoading(false);
 
+            if (response.data.analysis) {
+                const analysisResult = JSON.parse(response.data.analysis);
+                setResult(analysisResult);
+            } else {
+                setError('Analysis failed. Please try again.');
+            }
         } catch (error) {
             console.error('Error uploading files', error);
+            setError('An unexpected error occurred. Please try again.');
+            setLoading(false);
         }
     };
+
     const preventDefaults = (event) => {
         event.preventDefault();
         event.stopPropagation();
     };
+
+    const readFileContent = (file, setPreview) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            setPreview(reader.result);
+        };
+        reader.readAsText(file);
+    };
+
     return (
         <>
             <Navbar />
@@ -60,7 +81,10 @@ const ResumeAnalyzer = () => {
                         {resume ? resume.name : 'Drag & Drop Resume or Click to Upload'}
                         <input
                             type="file"
-                            onChange={(e) => setResume(e.target.files[0])}
+                            onChange={(e) => {
+                                setResume(e.target.files[0]);
+                                readFileContent(e.target.files[0], setResumePreview);
+                            }}
                             className={styles.fileInput}
                         />
                     </label>
@@ -68,25 +92,41 @@ const ResumeAnalyzer = () => {
                 <div
                     className={styles.fileInputContainer}
                     onDragOver={preventDefaults}
-                    onDrop={(event) => handleDrop(event, 'jd')}
+                    onDrop={(event) => handleDrop(event, 'jobDescription')}
                 >
                     <label className={styles.fileInputLabel}>
                         {jobDescription ? jobDescription.name : 'Drag & Drop Job Description or Click to Upload'}
                         <input
                             type="file"
-                            onChange={(e) => setJobDescription(e.target.files[0])}
+                            onChange={(e) => {
+                                setJobDescription(e.target.files[0]);
+                                readFileContent(e.target.files[0], setJobDescPreview);
+                            }}
                             className={styles.fileInput}
                         />
                     </label>
                 </div>
                 <button type="submit" className={styles.submitButton}>Analyze</button>
                 {loading && <div className={styles.loader}>Loading...</div>}
+                {error && <div className={styles.error}>{error}</div>}
             </form>
+            {resumePreview && (
+                <div className={styles.previewContainer}>
+                    <h3>Resume Preview:</h3>
+                    <pre className={styles.previewText}>{resumePreview}</pre>
+                </div>
+            )}
+            {jobDescPreview && (
+                <div className={styles.previewContainer}>
+                    <h3>Job Description Preview:</h3>
+                    <pre className={styles.previewText}>{jobDescPreview}</pre>
+                </div>
+            )}
             {result && (
                 <div className={styles.resultContainer}>
-                    <h3 className={styles.resultTitle}>Result of RESUME Analysis</h3>
+                    <h3 className={styles.resultTitle}>Result of Resume Analysis</h3>
                     <div className={styles.resultItem}>
-                        <strong className={styles.resultLabel}>Job Description Match: </strong>
+                        <strong className={styles.resultLabel}>Job Description Match:</strong>
                         <span className={styles.resultValue}>{result["JD Match"]}</span>
                     </div>
                     <div className={styles.resultItem}>

--- a/hiring-portal/src/Components/ResumeAnalyzer.jsx
+++ b/hiring-portal/src/Components/ResumeAnalyzer.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import axios from 'axios';
-import styles from '../CSS/resumeAnalyzer.module.css';
-import Navbar from "../Components/Navbar";
-import Footer from "../Components/Footer";
+import styles from '../CSS/resumeAnalyzer.module.css'
+import Navbar from "../Components/Navbar"
+import Footer from "../Components/Footer"
 
 const ResumeAnalyzer = () => {
     const [resume, setResume] = useState(null);
@@ -124,7 +124,7 @@ const ResumeAnalyzer = () => {
             )}
             {result && (
                 <div className={styles.resultContainer}>
-                    <h3 className={styles.resultTitle}>Result of Resume Analysis</h3>
+                    <h3 className={styles.resultTitle}>Result of RESUME Analysis</h3>
                     <div className={styles.resultItem}>
                         <strong className={styles.resultLabel}>Job Description Match:</strong>
                         <span className={styles.resultValue}>{result["JD Match"]}</span>

--- a/repo_structure.txt
+++ b/repo_structure.txt
@@ -14,9 +14,13 @@
 │   │   │   ├── companyController.js
 │   │   │   ├── contactController.js
 │   │   │   ├── directController.js
+│   │   │   ├── forgotPasswordController.js
 │   │   │   ├── jobController.js
 │   │   │   ├── otherApiController.js
+│   │   │   ├── otpVerifyController.js
 │   │   │   └── userController.js
+│   │   ├── middlewares/
+│   │   │   └── authMiddleware.js
 │   │   ├── models/
 │   │   │   ├── Application.js
 │   │   │   ├── Assesment.js
@@ -1196,14 +1200,15 @@
 │       ├── App.js
 │       ├── App.test.js
 │       ├── CSS/
+│       │   ├── About.module.css
 │       │   ├── ApplicationForm.css
+│       │   ├── ApplicationForm.module.css
 │       │   ├── NotFound.css
-│       │   ├── about.css
 │       │   ├── admin.css
 │       │   ├── ass.css
 │       │   ├── assessmentResults.css
 │       │   ├── backtotop.css
-│       │   ├── blog.css
+│       │   ├── blog.module.css
 │       │   ├── coding.css
 │       │   ├── company.css
 │       │   ├── contactus.css
@@ -1211,26 +1216,26 @@
 │       │   ├── createBlog.css
 │       │   ├── dashboard.css
 │       │   ├── employer.css
-│       │   ├── faqSection.css
-│       │   ├── footer.css
-│       │   ├── herosection.css
-│       │   ├── interview.css
+│       │   ├── faqSection.module.css
+│       │   ├── footer.module.css
+│       │   ├── herosection.module.css
+│       │   ├── interview.module.css
 │       │   ├── job.css
-│       │   ├── jobcard.css
+│       │   ├── jobcard.module.css
 │       │   ├── jobgrid.css
 │       │   ├── joblist.css
 │       │   ├── jobpage.css
 │       │   ├── jobpostform.css
 │       │   ├── jobs.css
 │       │   ├── manageJobs.css
-│       │   ├── middleview.css
-│       │   ├── navbar.css
-│       │   ├── newJobCard.css
-│       │   ├── postview.css
-│       │   ├── privacyPolicy.css
+│       │   ├── middleview.module.css
+│       │   ├── navbar.module.css
+│       │   ├── newJobCard.module.css
+│       │   ├── postview.module.css
+│       │   ├── privacyPolicy.module.css
 │       │   ├── profile.css
 │       │   ├── readMoreBlog.css
-│       │   ├── resumeAnalyzer.css
+│       │   ├── resumeAnalyzer.module.css
 │       │   ├── shortlist.css
 │       │   ├── signin.css
 │       │   ├── signup.css
@@ -1260,7 +1265,6 @@
 │       │   ├── Error404.jsx
 │       │   ├── Faqs.jsx
 │       │   ├── Footer.jsx
-│       │   ├── ForgotPassword.jsx
 │       │   ├── GoogleTranslate.jsx
 │       │   ├── GoogleTranslator.jsx
 │       │   ├── HeroSection.jsx


### PR DESCRIPTION
### Pull Request Title

**Issue Reference:**
#295 

**Description:**
Currently, the hiring portal only allows users to upload PDFs for analysis without previewing the extracted content. This can lead to issues if the text extraction does not work as expected. To enhance user experience, add an endpoint that allows users to upload a PDF and preview the first 1000 characters of the extracted text. This will help users ensure the text is correctly extracted before running the full analysis.

Changes made in- 
Backend ats.py to add endpoint for ats.py
Frontend resumeanalyser.js for the component to have the preview function for resume and job description

**Type of change:**
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [x] Enhancement

**Checklist:**
- [ ] I have tested my changes and verified that they work
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

